### PR TITLE
It should be possible to ignore std out errors when executing Run.Cmd

### DIFF
--- a/Source/Utility.Tests/RunFixture.cs
+++ b/Source/Utility.Tests/RunFixture.cs
@@ -1,0 +1,14 @@
+﻿using NUnit.Framework;
+
+namespace Nake.Utility
+{
+    public class RunFixture
+    {
+        [Test]
+        public void Cmd_should_be_able_to_ignore_std_out_errors()
+        {
+            const string msg = "error: message";
+            Assert.DoesNotThrow(() => Run.Cmd("Echo " + msg, ignoreStdOutErrors: true));
+        }
+    }
+}

--- a/Source/Utility.Tests/Utility.Tests.csproj
+++ b/Source/Utility.Tests/Utility.Tests.csproj
@@ -53,6 +53,7 @@
     <Compile Include="FileSetExtensionsFixture.cs" />
     <Compile Include="FileSetFixture.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="RunFixture.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Packages.config" />

--- a/Source/Utility/Run.cs
+++ b/Source/Utility/Run.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Diagnostics;
-using System.Linq;
 
 using Microsoft.Build.Tasks;
 using Microsoft.Build.Utilities;
@@ -39,11 +38,12 @@ namespace Nake
                 EchoOff = echoOff,
                 WorkingDirectory = workingDirectory ?? Location.CurrentDirectory(),
                 LogStandardErrorAsError = !ignoreStdOutErrors,
+                IgnoreStandardErrorWarningFormat = ignoreStdOutErrors,
                 IgnoreExitCode = ignoreExitCode,
                 EnvironmentVariables = environmentVariables ?? Env.Var.All(),
                 BuildEngine = new MSBuildEngineStub(disableStdOutLogging),
             };
-            
+
             if (!task.Execute() || task.Log.HasLoggedErrors)
                 throw new ApplicationException(string.Format("{0} failed", task.GetType()));
             


### PR DESCRIPTION
`Run.Cmd("Echo error: message")` fails to execute because msbuild by default
parses output to find errors\warning.
`Exec.IgnoreStandardErrorWarningFormat` property controls that behavior.
Probably, the right way to disable output matching would be to propagate
that config as a Cmd parameter, but `Cmd` already has `ignoreStdOutErrors`
parameter which perfectly fits these needs.
Setting `ignoreStdOutErrors` to `true` would ignore both errors logged to
std error output and error lines logged to std output.

### Details
My use case was executing NUnit via Run.Cmd method:

```csharp
var exitCode = Cmd("{nunitExe} {nunitArgs}", ignoreExitCode: true, ignoreStdOutErrors: true);
```

For cases when NUnit test method throws an exception:

```csharp
[Test]
public void Test()
{
    throw new Exception("Foo");
}
```

I receive following output:
```
The command "Source\Packages\NUnit.Runners.2.6.4\tools\nunit-console.exe Test.dll /noshadow /nologo /result:output\test-results.xml" exited with code 3.
Microsoft.Build.Tasks.Exec failed
```
And nake itself is stopped with exit code = -1.

**Expected behavior:**

Since `ignoreStdOutErrors` is set to `true` I expect that `Cmd` method should be executed without failing, and should return exit code of underlying program (nunit).

Looks like following behavior was broken in [this changeset](https://github.com/yevhen/Nake/commit/d765058801979d765cdafea31d378d452e6270bb#diff-efc87bc0c086793af2ce0ccf9fa92df4L43).