### PR TITLE
Fixed Fs.Copy and Fs.Move methods that accept source files pattern param

### DIFF
--- a/Source/Utility/FS.cs
+++ b/Source/Utility/FS.cs
@@ -8,7 +8,7 @@ using MSBuildTask = Microsoft.Build.Utilities.Task;
 namespace Nake
 {
     /// <summary>
-    /// File-system convinience methods
+    /// File-system convenience methods
     /// </summary>
     public static class FS
     {
@@ -72,7 +72,7 @@ namespace Nake
             bool overwriteReadOnlyFiles = false, 
             bool skipUnchangedFiles = true)
         {
-            Copy(new FileSet(sourceFiles).ToArray(), destinationFolder, overwriteReadOnlyFiles, skipUnchangedFiles);
+            Copy(new FileSet().Add(sourceFiles).ToArray(), destinationFolder, overwriteReadOnlyFiles, skipUnchangedFiles);
         }
 
         /// <summary>
@@ -124,7 +124,7 @@ namespace Nake
             string destinationFolder, 
             bool overwriteReadOnlyFiles = false)
         {
-            Move(new FileSet(sourceFiles).ToArray(), destinationFolder, overwriteReadOnlyFiles);
+            Move(new FileSet().Add(sourceFiles).ToArray(), destinationFolder, overwriteReadOnlyFiles);
         }
 
         /// <summary>


### PR DESCRIPTION
FileSet constructor accepts `BasePath` parameter, not file matching pattern.