### PR TITLE
Fix issue causing Nake temp files appear in a root directory

### DIFF
--- a/Source/Nake/Caching.cs
+++ b/Source/Nake/Caching.cs
@@ -110,7 +110,21 @@ namespace Nake
 
         string StringHash(string s)
         {
-            return Convert.ToBase64String(sha1.ComputeHash(Encoding.UTF8.GetBytes(s)));
+            var hash = Convert.ToBase64String(sha1.ComputeHash(Encoding.UTF8.GetBytes(s)));
+            return EnsureSafePath(hash);
+        }
+
+        string EnsureSafePath(string s)
+        {
+            // Hashed value is used as a directory name.
+            // According to http://en.wikipedia.org/wiki/Base64 Base64 could contain '/' symbol.
+            // It breaks Path.Combine(temp, hash) sematics. 
+            // E.g Path.Combine("c:\temp\nake", "/somebase64string") would produce '/somebase64string'
+            // which is not quite expected.
+            // Workaround it by replacing dangerous character with '_' symbol.
+            // It's used in some alternative Base64 implementations:
+            // http://en.wikipedia.org/wiki/Base64#Variants_summary_table
+            return s.Replace(@"/", "_");
         }
 
         public BuildResult Find(Task[] tasks)


### PR DESCRIPTION
Nake uses Base64 encoding to generate temporary directory names. And
then combines them with a user defined TempDirectory via Path.Combine.
Since Base64 encoding allows '/' character, result of combining folders
might not be expected. For example:
```  Path.Combine("C:\Temp", "/base64string");```

will results in a '/base64string' folder omitting the root Temp folder.
Thus Nake temporary files would be stored in a root folder like `C:\`
instead of a temp folder.

Fixed it by replacing '/' character in a hash with '_' character. As it
occurs, it is used in some alternative implementations of Base64:
http://en.wikipedia.org/wiki/Base64#Variants_summary_table

Below is screenshot of temp directories structure created before
and after fix.
![image](https://cloud.githubusercontent.com/assets/147127/7102262/c46242ce-e083-11e4-8406-6c83268cd600.png)
