### PR TITLE
Allow task parameters to be case insensitive

### DIFF
--- a/Source/Nake.Tests/Invoking_tasks.cs
+++ b/Source/Nake.Tests/Invoking_tasks.cs
@@ -184,5 +184,22 @@ namespace Nake
 
             Assert.That(int.Parse(Env.Var["counter"]), Is.EqualTo(2));
         }
+
+        [Test]
+        public void Parameter_names_are_case_insensitive()
+        {
+            Build(@"  
+                [Task] void Task(string paramValue) 
+                {
+                     Env.Var[""paramValue""] = paramValue;
+                }
+            ");
+
+            Invoke("Task", new TaskArgument("paramvalue", "lowercase"));
+            Assert.That(Env.Var["paramValue"], Is.EqualTo("lowercase"));
+
+            Invoke("Task", new TaskArgument("paramValue", "camelCase"));
+            Assert.That(Env.Var["paramValue"], Is.EqualTo("camelCase"));
+        }
     }
 }

--- a/Source/Nake.Tests/What_considered_being_a_task.cs
+++ b/Source/Nake.Tests/What_considered_being_a_task.cs
@@ -116,6 +116,10 @@ namespace Nake
                 BadTaskDeclaration<TaskSignatureViolationException>(
                     @"[Task] public static void HasRefParameters(ref int p) {}"
                 ),
+
+                BadTaskDeclaration<TaskSignatureViolationException>(
+                    @"[Task] void DuplicateParams(int p, int P) {}"
+                )
             };
         }
 

--- a/Source/Nake/Exceptions.cs
+++ b/Source/Nake/Exceptions.cs
@@ -108,7 +108,7 @@ namespace Nake
     class TaskSignatureViolationException : NakeException
     {
         public TaskSignatureViolationException(string method)
-            : base("Bad task method signature: '{0}'. Should be public static void non-generic, have no out or ref parameters and all parameters should be either bool, int, string or enum type", method)
+            : base("Bad task method signature: '{0}'. Should be public static void non-generic, have no out or ref parameters, have no duplicate parameters that differ only by case and all parameters should be either bool, int, string or enum type", method)
         {}
     }
 

--- a/Source/Nake/Task.cs
+++ b/Source/Nake/Task.cs
@@ -35,9 +35,14 @@ namespace Nake
 
         static void CheckSignature(IMethodSymbol symbol)
         {
+            bool hasDuplicateParameters = symbol.Parameters
+                .GroupBy(p => p.Name, StringComparer.OrdinalIgnoreCase)
+                .Any(p => p.Count() > 1);
+
             if (!symbol.ReturnsVoid ||                
                 symbol.IsGenericMethod ||
-                symbol.Parameters.Any(p => p.RefKind != RefKind.None || !TypeConverter.IsSupported(p.Type)))
+                symbol.Parameters.Any(p => p.RefKind != RefKind.None || !TypeConverter.IsSupported(p.Type)) ||
+                hasDuplicateParameters)
                 throw new TaskSignatureViolationException(symbol.ToString());
         }  
 

--- a/Source/Nake/TaskInvocation.cs
+++ b/Source/Nake/TaskInvocation.cs
@@ -54,7 +54,7 @@ namespace Nake
 
         ParameterInfo GetParameterByName(string name)
         {
-            return method.GetParameters().SingleOrDefault(x => x.Name == name);
+            return method.GetParameters().SingleOrDefault(x => string.Equals(x.Name, name, StringComparison.OrdinalIgnoreCase));
         }
 
         object Convert(TaskArgument arg, int position, ParameterInfo parameter)


### PR DESCRIPTION
Thus these invocations would be allowed
`  nake db dbname=db --skipsamples`
`  nake db dbName=db --skipSamples`