### PR TITLE
Improve logging

### DIFF
--- a/Source/Utility/MSBuild.EngineStub.cs
+++ b/Source/Utility/MSBuild.EngineStub.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections;
-
+using System.Linq;
 using Microsoft.Build.BuildEngine;
 using Microsoft.Build.Framework;
 
@@ -8,11 +8,11 @@ namespace Nake
 {
     class MSBuildEngineStub : IBuildEngine
     {
-        readonly ConsoleLogger logger;
+        readonly NakeLogger logger;
 
         public MSBuildEngineStub(bool quiet = false)
         {
-            logger = new ConsoleLogger(quiet ? LoggerVerbosity.Quiet : LoggerVerbosity.Normal);
+            logger = new NakeLogger(quiet ? LoggerVerbosity.Quiet : LoggerVerbosity.Normal);
         }
 
         public void LogErrorEvent(BuildErrorEventArgs e)
@@ -58,6 +58,25 @@ namespace Nake
         public string ProjectFileOfTaskNode
         {
             get; set;
+        }
+
+        private class NakeLogger : ConsoleLogger
+        {
+            public NakeLogger(LoggerVerbosity verbosity)
+                : base(verbosity, new WriteHandler(Log.Out), SetColor, Console.ResetColor)
+            {
+
+            }
+
+            private static void SetColor(ConsoleColor color)
+            {
+                var background = Console.BackgroundColor;
+                var alternativeColor = new[] { ConsoleColor.Gray, ConsoleColor.Black }.First(c => background != c);
+
+                Console.ForegroundColor = color != background
+                    ? color
+                    : alternativeColor;
+            }
         }
     }
 }


### PR DESCRIPTION
Motivation was to simplify this kind of code:
```csharp
[Task] void LatestVersion()
{
    Message("Retrieving latest Some.Private.Package version...");
    var tempFile = Path.Combine(Path.GetTempPath(), "Some.Private.Package.version");
    Cmd(@"Tools\nuget.exe list Some.Private.Package > {tempFile}");
    var content = File.ReadAllText(tempFile);
    var match = Regex.Match(content, @"Some.Private.Package (\S*)(\s*)$", RegexOptions.Multiline);
    if (!match.Success)
        throw new ApplicationException("Could not determine latest Some.Private.Package version");

    var version = match.Groups[1].Value;
    Message("Latest Some.Private.Package version - {version}");
}
```

To make this happen I've forwarded `Run.Cmd` and `Run.Exec` output to nake's own `Log`. 
Also I've added scoped log tracer to simplify tracing of `Log.Out`.

Now example code above should look like this:
```csharp
[Task] void LatestVersion()
{
    Message("Retrieving latest Some.Private.Package version...");
    using (var nugetTrace = Log.TraceOut())
    {
        Cmd(@"Tools\nuget.exe list");
        var match = Regex.Match(nugetTrace.Trace, @"Some.Private.Package (\S*)(\s*)$", RegexOptions.Multiline);
        if (!match.Success)
            throw new ApplicationException("Could not determine latest Some.Private.Package version");
        var version = match.Groups[1].Value;
        Message("Latest Some.Private.Package version - {version}");
    }    
}
```
